### PR TITLE
Resolvable object deleted date stamps get removed if the RO record 'reappears' in another sync

### DIFF
--- a/populator/management/commands/_cache_data.py
+++ b/populator/management/commands/_cache_data.py
@@ -11,7 +11,7 @@ def sync_datasets(migration_dataset_ids):
     deleted_datasets = Dataset.objects.exclude(id__in=migration_dataset_ids)
     log_time(start, ', '.join([x.id for x in deleted_datasets]))
     deleted_datasets.update(deleted_date=date.today())
-    log_time(start, 'syncing datasets')
+    log_time(start, 'synced datasets')
 
     ResolvableObject.objects.filter(dataset__id__in=[x.id for x in deleted_datasets]).update(deleted_date=date.today())
 
@@ -114,10 +114,12 @@ def populate_temp_updated_table(limit, offset):
 
 
 def insert_history():
+    # Exclude records where the only thing that changes is the modified date
     with connection.cursor() as cursor:
         cursor.execute("""INSERT INTO populator_history(resolvable_object_id, changed_data, changed_date)
                           SELECT id, changed_data, CURRENT_DATE
-                          FROM temp_updated""")
+                          FROM temp_updated
+                          WHERE NOT (changed_data ?& array['modified'])""")
 
 
 def update_website_resolvableobject():

--- a/populator/management/commands/_cache_data.py
+++ b/populator/management/commands/_cache_data.py
@@ -123,7 +123,7 @@ def insert_history():
 def update_website_resolvableobject():
     with connection.cursor() as cursor:
         cursor.execute("""UPDATE website_resolvableobject 
-                          SET data = temp_updated.data
+                          SET data = temp_updated.data, deleted_date = NULL
                           FROM temp_updated
                           WHERE website_resolvableobject.id = temp_updated.id""")
 

--- a/populator/management/commands/populate_resolver.py
+++ b/populator/management/commands/populate_resolver.py
@@ -64,7 +64,7 @@ class Command(BaseCommand):
 
         if not options['skip']:
             start = datetime.now()
-            #_cache_data.sync_datasets(dataset_ids)
+            _cache_data.sync_datasets(dataset_ids)
             log_time(start, 'caching complete')
 
         start = datetime.now()
@@ -83,15 +83,16 @@ def create_duplicates_file(file='/code/duplicates.txt'):
 def sync_dataset(dataset):
     dataset['label'] = dataset['title']
     dataset['sameas'] = dataset['doi']
+    key = dataset.pop('key')
     del dataset['title'], dataset['doi']
     try:
-        dataset_object = Dataset.objects.get(id=dataset['key'])
+        dataset_object = Dataset.objects.get(id=key)
         if dataset_object.data['modified'] == dataset['modified']:
             return False
         dataset_object.data = dataset
         dataset_object.save()
     except Dataset.DoesNotExist:
-        dataset_object = Dataset.objects.create(id=dataset['key'], data=dataset)
+        dataset_object = Dataset.objects.create(id=key, data=dataset)
     return dataset_object
 
 

--- a/populator/tests/test_cache_data.py
+++ b/populator/tests/test_cache_data.py
@@ -58,7 +58,7 @@ class CacheDataTest(TransactionTestCase):
     def create_ro_migration(self, data={}, id_='a'):  # The newly imported data
         ResolvableObjectMigration.objects.create(id=id_, type='occurrence', dataset_id=self.dataset.id, data=data, parent_id=None)
 
-    def assert_equal(self, iterable1, iterable2):  # Necessary as assertEqual does not compare json fields
+    def assert_json_equal(self, iterable1, iterable2):  # Necessary as assertEqual does not compare json fields
         self.assertEqual([model_to_dict(x) for x in iterable1], [model_to_dict(x) for x in iterable2])
 
     def test_create_temp_updated_table(self):
@@ -79,7 +79,7 @@ class CacheDataTest(TransactionTestCase):
         self.create_ro_migration({'scientificname': 'same', 'location': 'new updated'})
         cache_data.merge_in_new_data()
         expected = History(id=1, resolvable_object_id='a', changed_data={'location': 'old original'}, changed_date=date.today())
-        self.assert_equal(History.objects.all(), [expected])
+        self.assert_json_equal(History.objects.all(), [expected])
 
     def test_records_multiple_items_in_history_table(self):
         self.create_ro({'scientificname': 'same', 'location': 'old original'})
@@ -89,21 +89,21 @@ class CacheDataTest(TransactionTestCase):
         cache_data.merge_in_new_data()
         expected_a = History(id=1, resolvable_object_id='a', changed_data={'location': 'old original'}, changed_date=date.today())
         expected_b = History(id=2, resolvable_object_id='b', changed_data={'location': 'old original'}, changed_date=date.today())
-        self.assert_equal(History.objects.all(), [expected_a, expected_b])
+        self.assert_json_equal(History.objects.all(), [expected_a, expected_b])
 
     def test_records_copy_of_deleted_data_items_in_history_table(self):
         self.create_ro({'scientificname': 'same', 'incorrect_data': 'to be deleted'})
         self.create_ro_migration({'scientificname': 'same'})
         cache_data.merge_in_new_data()
         expected = History(id=1, resolvable_object_id='a', changed_data={'incorrect_data': 'to be deleted'}, changed_date=date.today())
-        self.assert_equal(History.objects.all(), [expected])
+        self.assert_json_equal(History.objects.all(), [expected])
 
     def test_adds_none_for_new_created_data_items_history_table(self):
         self.create_ro({'scientificname': 'same'})
         self.create_ro_migration({'scientificname': 'same', 'location': 'new created'})
         cache_data.merge_in_new_data()
         expected = History(id=1, resolvable_object_id='a', changed_data={'location': None}, changed_date=date.today())
-        self.assert_equal(History.objects.all(), [expected])
+        self.assert_json_equal(History.objects.all(), [expected])
 
     def test_does_not_add_to_history_table_if_no_changes(self):
         self.create_ro({'no_change': 'should not be included in history'})
@@ -126,7 +126,7 @@ class CacheDataTest(TransactionTestCase):
     def test_creates_new_single_record_in_resolvableobject_table(self):
         self.create_ro_migration({'new_record': 'new'})
         cache_data.merge_in_new_data()
-        self.assert_equal(ResolvableObject.objects.all(), [ResolvableObject(id='a', type='occurrence', data={'new_record': 'new'}, dataset=self.dataset)])
+        self.assert_json_equal(ResolvableObject.objects.all(), [ResolvableObject(id='a', type='occurrence', data={'new_record': 'new'}, dataset=self.dataset)])
 
     def test_creates_new_multiple_records_in_resolvable_object_table(self):
         self.create_ro_migration({'new_record': 'new'})
@@ -136,17 +136,27 @@ class CacheDataTest(TransactionTestCase):
             ResolvableObject(id='a', data={'new_record': 'new'}, type='occurrence', dataset=self.dataset),
             ResolvableObject(id='b', data={'new_record': 'new'}, type='occurrence', dataset=self.dataset),
         ]
-        self.assert_equal(ResolvableObject.objects.all(), expected)
+        self.assert_json_equal(ResolvableObject.objects.all(), expected)
 
     def test_adds_deleted_datestamp_for_removed_records_in_resolvable_object_table(self):
         self.create_ro({'no_change': 'same'})
         cache_data.merge_in_new_data()
         expected = ResolvableObject(id='a', data={'no_change': 'same'}, deleted_date=date.today(), type='occurrence', dataset=self.dataset)
-        self.assert_equal(ResolvableObject.objects.all(), [expected])
+        self.assert_json_equal(ResolvableObject.objects.all(), [expected])
 
     def test_does_not_overwrite_preexisting_deleted_datestamps(self):
         past_date_d = date.today() - timedelta(days=4)
         ResolvableObject.objects.create(id='1', data={'none': 'none'}, deleted_date=past_date_d, dataset=self.dataset, type='occurrence')
         cache_data.merge_in_new_data()
         self.assertEqual(ResolvableObject.objects.first().deleted_date, past_date_d)
+
+    def test_record_is_deleted_and_then_gets_added_again(self):
+        # I have no idea what to do here. For the moment we can assume it's a blip and remove the deleted date again?
+        self.create_ro({'key': 'value'})
+        cache_data.merge_in_new_data()
+        self.assertEqual(ResolvableObject.objects.first().deleted_date, date.today())
+        self.create_ro_migration({'key': 'value2'})
+        cache_data.merge_in_new_data()
+        self.assertEqual(ResolvableObject.objects.count(), 1)
+        self.assertEqual(ResolvableObject.objects.first().deleted_date, None)
 

--- a/populator/tests/test_cache_data.py
+++ b/populator/tests/test_cache_data.py
@@ -81,6 +81,12 @@ class CacheDataTest(TransactionTestCase):
         expected = History(id=1, resolvable_object_id='a', changed_data={'location': 'old original'}, changed_date=date.today())
         self.assert_json_equal(History.objects.all(), [expected])
 
+    def test_ignores_changes_to_modified_fields(self):
+        self.create_ro({'scientificname': 'same', 'modified': '2011-01-01'})
+        self.create_ro_migration({'scientificname': 'same', 'modified': '2022-02-02'})
+        cache_data.merge_in_new_data()
+        self.assert_json_equal(History.objects.all(), [])
+
     def test_records_multiple_items_in_history_table(self):
         self.create_ro({'scientificname': 'same', 'location': 'old original'})
         self.create_ro_migration({'scientificname': 'same', 'location': 'new updated'})
@@ -159,4 +165,3 @@ class CacheDataTest(TransactionTestCase):
         cache_data.merge_in_new_data()
         self.assertEqual(ResolvableObject.objects.count(), 1)
         self.assertEqual(ResolvableObject.objects.first().deleted_date, None)
-

--- a/populator/tests/test_populate_resolver.py
+++ b/populator/tests/test_populate_resolver.py
@@ -13,10 +13,11 @@ class SyncDatasetTest(TestCase):
     endpoints_example = [{'type': 'DWC_ARCHIVE', 'url': 'http://data.gbif.no/archive.do?r=dataset'}]
 
     def test_sync_dataset_creates_datasets(self):
+        self.assertEqual(Dataset.objects.count(), 0)
         dataset_details = {'title': '1', 'endpoints': self.endpoints_example, 'doi': 'doi:1', 'comments': '', 'key': 'a', 'modified': datetime.now().strftime('%Y-%m-%dT%H:%M:%S+0000')}
         sync_dataset(dataset_details)
-        self.assertEqual(Dataset.objects.all().count(), 1)
-        self.assertEqual(Dataset.objects.all()[0].data['key'], 'a')
+        self.assertEqual(Dataset.objects.count(), 1)
+        self.assertEqual(Dataset.objects.all()[0].id, 'a')
 
     def test_sync_dataset_updates_datasets(self):
         original = {'label': '1-no-change', 'endpoints': self.endpoints_example, 'sameas': 'doi:1', 'comments': '', 'key': 'a', 'modified': '2000-12-12T00:00:00.0+0000'}

--- a/website/serializers.py
+++ b/website/serializers.py
@@ -12,11 +12,12 @@ class HistorySerializer(serializers.ModelSerializer):
 class DatasetSerializer(serializers.HyperlinkedModelSerializer):
     class Meta:
         model = Dataset
-        fields = ('data', )
+        fields = ('data', 'id', 'created_date', 'deleted_date')
 
     def to_representation(self, instance):
         ret = super().to_representation(instance)
-        return ret['data']
+        data = ret.pop('data')
+        return {**data, **ret}
 
 
 class ResolvableObjectSerializer(serializers.ModelSerializer):
@@ -31,7 +32,7 @@ class ResolvableObjectSerializer(serializers.ModelSerializer):
         prefixed_object = {'dwc:%s' % key: value for key, value in ret['data'].items()}
         prefixed_object['data-type'] = ret['type']
         dataset = ret['dataset']
-        prefixed_object['dataset'] = {'label': dataset['label'], 'key': dataset['key'], 'type': dataset['type']}
+        prefixed_object['dataset'] = {'label': dataset['label'], 'id': dataset['id'], 'type': dataset['type']}
         prefixed_object['deleted_date'] = ret['deleted_date']
         prefixed_object['@context'] = {'dc': 'http://purl.org/dc/elements/1.1/', 'dwc': 'http://rs.tdwg.org/dwc/terms/', 'owl': 'https://www.w3.org/tr/owl-ref/'}
 

--- a/website/tests/test_views.py
+++ b/website/tests/test_views.py
@@ -7,7 +7,7 @@ from rest_framework.reverse import reverse
 
 class HistoryViewTests(APITestCase):
     def setUp(self):
-        self.dataset = Dataset.objects.create(id='dataset_id', data={'label': 'My dataset', 'key': 'a', 'type': 'event'})
+        self.dataset = Dataset.objects.create(id='dataset_id', data={'label': 'My dataset', 'type': 'event'})
         self.resolvable_object = ResolvableObject.objects.create(id='a', data={'test': 'a'}, dataset=self.dataset)
         History.objects.create(resolvable_object=self.resolvable_object, changed_data={'test': 'b'})
 
@@ -60,7 +60,7 @@ class HistoryViewTests(APITestCase):
 
 class ResolverViewTests(APITestCase):
     def setUp(self):
-        self.dataset = Dataset.objects.create(id='dataset_id', data={'label': 'My dataset', 'key': 'a', 'type': 'event'})
+        self.dataset = Dataset.objects.create(id='a', data={'label': 'My dataset', 'type': 'event'})
 
     def test_displays_index(self):
         Statistic.objects.set_total_count()
@@ -172,7 +172,7 @@ class ResolverViewTests(APITestCase):
                              'dwc:basisofrecord': 'preservedspecimen',
                              'data-type': '',
                              'deleted_date': None,
-                             'dataset': {'key': 'a', 'label': 'my dataset', 'type': 'event'},
+                             'dataset': {'id': 'a', 'label': 'my dataset', 'type': 'event'},
                              '@context': {'dc': 'http://purl.org/dc/elements/1.1/',
                                           'dwc': 'http://rs.tdwg.org/dwc/terms/',
                                           'owl': 'https://www.w3.org/tr/owl-ref/'}}
@@ -186,7 +186,7 @@ class ResolverViewTests(APITestCase):
                              '@id': 'http://purl.org/gbifnorway/id/urn:uuid:5c0884ce-608c-4716-ba0e-cb389dca5580',
                              'data-type': '',
                              'deleted_date': None,
-                             'dataset': {'key': 'a', 'label': 'my dataset', 'type': 'event'},
+                             'dataset': {'id': 'a', 'label': 'my dataset', 'type': 'event'},
                              '@context': {'dc': 'http://purl.org/dc/elements/1.1/',
                                           'dwc': 'http://rs.tdwg.org/dwc/terms/',
                                           'owl': 'https://www.w3.org/tr/owl-ref/',

--- a/website/tests/test_views.py
+++ b/website/tests/test_views.py
@@ -123,6 +123,19 @@ class ResolverViewTests(APITestCase):
         self.assertEqual(len(results['results']), 1)
         self.assertEqual(results['results'][0]['dwc:scientificname'], 'galium odoratum')
 
+    def test_filters_on_dataset_id(self):
+        id = 'urn:uuid:5c0884ce-608c-4716-ba0e-cb389dca5580'
+        ResolvableObject.objects.create(id=id, dataset=self.dataset, data={'id': id, 'basisOfRecord': 'preservedspecimen', 'scientificname': 'Galium odoratum'})
+        new_dataset = Dataset.objects.create(id='b', data={'label': 'New dataset', 'type': 'occurrence'})
+        id = 'urn:uuid:6c0884ce-608c-4716-ba0e-cb389dca5581'
+        ResolvableObject.objects.create(id=id, dataset=new_dataset, data={'id': id, 'basisOfRecord': 'preservedspecimen', 'scientificname': 'Eudyptes moseleyi'})
+
+        url = reverse('resolvableobject-list')
+        response = self.client.get(url + '?dataset_id=b', HTTP_ACCEPT='application/ld+json')
+        results = json.loads(response.content.decode('utf-8').lower())
+        self.assertEqual(len(results['results']), 1)
+        self.assertEqual(results['results'][0]['dataset']['id'], 'b')
+
     def test_filters_on_multiple(self):
         id = 'urn:uuid:5c0884ce-608c-4716-ba0e-cb389dca5580'
         ResolvableObject.objects.create(id=id, dataset=self.dataset, data={'id': id, 'basisOfRecord': 'preservedspecimen', 'scientificname': 'Galium odoratum'})

--- a/website/views.py
+++ b/website/views.py
@@ -52,14 +52,14 @@ class ResolvableObjectViewSet(viewsets.ReadOnlyModelViewSet):
     serializer_class = ResolvableObjectSerializer
     pagination_class = CustomPagination
     filter_backends = [DjangoFilterBackend]
-    filter_fields = { 'deleted_date': ['gte', 'lte', 'exact'], 'dataset_id': ['exact'] }
+    filter_fields = { 'deleted_date': ['gte', 'lte', 'exact'], 'dataset_id': ['exact'], 'type': ['exact'] }
 
     def get_queryset(self):
         query_params = self.request.query_params
-        data_args = {key: item for key, item in query_params.items() if key not in ['offset', 'limit', 'format', 'type', '_add_counts']}
-        args = {'data__contains': data_args}
-        if 'type' in query_params:
-            args['type'] = query_params['type']
+        non_data_fields =['offset', 'limit', 'format', 'type', '_add_counts', 'dataset_id', 'deleted_date', 'deleted_date__gte', 'deleted_date__lte', 'type']
+        data_args = {key: item for key, item in query_params.items() if key not in non_data_fields }
+        args = { 'data__contains': data_args }
+
         if '_add_counts' in query_params and query_params['_add_counts'] == 'true':
             self.pagination_class = CustomCountPagination
         return ResolvableObject.objects.filter(**args)


### PR DESCRIPTION
Resolvable object deleted date stamps get removed if the RO record 'reappears' in another sync, i.e. Sync 1 -> record gets added to dataset, Sync 2 -> record gets deleted from dataset [deleted_date stamp added], Sync 3 -> record appears in dataset again [deleted_date stamp removed]

Also, does not create a history record if the only field that changes is the 'modified' field.

Also remove dataset.data['key'] (which is used to populate dataset id pk) as it's confusing to have it in the dataset object twice.